### PR TITLE
response.json is a method, needs to be called to get a string.

### DIFF
--- a/keen/api.py
+++ b/keen/api.py
@@ -56,5 +56,5 @@ class KeenApi(object):
         payload = event.to_json()
         response = requests.post(url, data=payload, headers=headers)
         if response.status_code != 201:
-            error = response.json
+            error = response.json()
             raise exceptions.KeenApiError(error)


### PR DESCRIPTION
Before:

```
Traceback (most recent call last):
  File "keen_test.py", line 15, in <module>
    main()
  File "keen_test.py", line 11, in main
    'event_type': 'change-merged',
  File "/usr/local/lib/python2.7/dist-packages/keen/client.py", line 96, in add_event
    self.persistence_strategy.persist(event)
  File "/usr/local/lib/python2.7/dist-packages/keen/persistence_strategies.py", line 37, in persist
    self.api.post_event(event)
  File "/usr/local/lib/python2.7/dist-packages/keen/api.py", line 61, in post_event
    raise exceptions.KeenApiError(error)
  File "/usr/local/lib/python2.7/dist-packages/keen/exceptions.py", line 34, in __init__
    api_error["message"], api_error["error_code"]
TypeError: 'instancemethod' object has no attribute '__getitem__'
```

After:

```
Traceback (most recent call last):
  File "keen_test.py", line 15, in <module>
    main()
  File "keen_test.py", line 11, in main
    'event_type': 'change-merged',
  File "/usr/local/lib/python2.7/dist-packages/keen/client.py", line 96, in add_event
    self.persistence_strategy.persist(event)
  File "/usr/local/lib/python2.7/dist-packages/keen/persistence_strategies.py", line 37, in persist
    self.api.post_event(event)
  File "/usr/local/lib/python2.7/dist-packages/keen/api.py", line 61, in post_event
    raise exceptions.KeenApiError(error)
keen.exceptions.KeenApiError: Error from Keen API. Details:
 Message: Specified API Key is invalid. API Key: 'None'.
Code: InvalidApiKeyError
```
