### PR TITLE
Feature: API Retries

### DIFF
--- a/keen/api.py
+++ b/keen/api.py
@@ -213,7 +213,7 @@ class KeenApi(object):
                     "Authorization": self.read_key
                 },
                 'retries': retries or self.default_retries,  # retry count
-                'expected': 200,  # expected return code
+                'expected': (200, 304),  # expected return code
                 'return_key': 'result',  # result location in response
                 'default_value': {},  # default value if no `return_key`
                 '_strict': strict  # whether to raise exceptions immediately
@@ -223,6 +223,10 @@ class KeenApi(object):
     def fulfill(self, method, url, retries=None, expected=200, return_key=None, default_value={}, _retry_count=0, _strict=False, *args, **kwargs):
 
         ''' Fulfill an HTTP request to Keen's API. '''
+
+        # allow multiple success codes
+        if not isinstance(expected, tuple):
+            expected = (expected,)
 
         for attempt in self.range(1, (retries or 1) + 1):
 
@@ -240,7 +244,7 @@ class KeenApi(object):
 
             else:
                 # check for unexpected responses
-                if expected and result.status_code != expected:
+                if expected and result.status_code not in expected:
                     raise exceptions.KeenApiError(response)  # raise immediately, it worked and failed
 
                 break  # things worked, stop trying


### PR DESCRIPTION
Adds functionality for a variable number of retries when sending requests to Keen IO.

You can set either `default_retries` on a `KeenApi` object, or override the default (currently set to `0`) by passing `retries=<int>` to `post_event`, `post_events` or `query`.

This also includes the SSL improvements in pull request #16.
