### PR TITLE
Add Master key to keen library

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This client is known to work on Python 2.6, 2.7, 3.2 and 3.3
 
 To use this client with the Keen IO API, you have to configure your Keen IO Project ID and its access keys (if you need an account, [sign up here](https://keen.io/) - it's free).
 
-Setting a write key is required for publishing events. Setting a read key is required for running queries. The recommended way to set this configuration information is via the environment. The keys you can set are `KEEN_PROJECT_ID`, `KEEN_WRITE_KEY`, and `KEEN_READ_KEY`.
+Setting a write key is required for publishing events. Setting a read key is required for running queries. The recommended way to set this configuration information is via the environment. The keys you can set are `KEEN_PROJECT_ID`, `KEEN_WRITE_KEY`, `KEEN_READ_KEY`, and `KEEN_MASTER_KEY`.
 
 If you don't want to use environment variables for some reason, you can directly set values as follows:
 
@@ -28,6 +28,7 @@ If you don't want to use environment variables for some reason, you can directly
     keen.project_id = "xxxx"
     keen.write_key = "yyyy"
     keen.read_key = "zzzz"
+    keen.master_key = "abcd"
 ```
 
 You can also configure unique client instances as follows:
@@ -38,7 +39,8 @@ You can also configure unique client instances as follows:
     client = KeenClient(
         project_id="xxxx",
         write_key="yyyy",
-        read_key="zzzz"
+        read_key="zzzz",
+        master_key="abcd"
     )
 ```
 
@@ -154,6 +156,7 @@ By default, POST requests will timeout after 305 seconds. If you want to manuall
         project_id="xxxx",
         write_key="yyyy",
         read_key="zzzz",
+        master_key="abcd",
         post_timeout=100
 
     )

--- a/keen/__init__.py
+++ b/keen/__init__.py
@@ -8,16 +8,18 @@ _client = None
 project_id = None
 write_key = None
 read_key = None
+master_key = None
 
 
 def _initialize_client_from_environment():
-    global _client, project_id, write_key, read_key
+    global _client, project_id, write_key, read_key, master_key
 
     if _client is None:
         # check environment for project ID and keys
         project_id = project_id or os.environ.get("KEEN_PROJECT_ID")
         write_key = write_key or os.environ.get("KEEN_WRITE_KEY")
         read_key = read_key or os.environ.get("KEEN_READ_KEY")
+        master_key = master_key or os.environ.get("KEEN_MASTER_KEY")
 
         if not project_id:
             raise InvalidEnvironmentError("Please set the KEEN_PROJECT_ID environment variable or set keen.project_id!")

--- a/keen/__init__.py
+++ b/keen/__init__.py
@@ -26,7 +26,8 @@ def _initialize_client_from_environment():
 
         _client = KeenClient(project_id,
                              write_key=write_key,
-                             read_key=read_key)
+                             read_key=read_key,
+                             master_key=master_key)
 
 
 def add_event(event_collection, body, timestamp=None):

--- a/keen/api.py
+++ b/keen/api.py
@@ -50,7 +50,8 @@ class KeenApi(object):
     # self says it belongs to KeenApi/andOr is the object passed into KeenApi
     # __init__ create keenapi object whenever KeenApi class is invoked
     def __init__(self, project_id, write_key=None, read_key=None,
-                 base_url=None, api_version=None, get_timeout=None, post_timeout=None):
+                 base_url=None, api_version=None, get_timeout=None, post_timeout=None,
+                 master_key=None):
         """
         Initializes a KeenApi object
 
@@ -60,6 +61,7 @@ class KeenApi(object):
         :param base_url: optional, set this to override where API requests
         are sent
         :param api_version: string, optional, set this to override what API
+        :param master_key: a Keen IO Master API Key
         version is used
         """
         # super? recreates the object with values passed into KeenApi
@@ -67,6 +69,7 @@ class KeenApi(object):
         self.project_id = project_id
         self.write_key = write_key
         self.read_key = read_key
+        self.master_key = master_key
         if base_url:
             self.base_url = base_url
         if api_version:

--- a/keen/client.py
+++ b/keen/client.py
@@ -57,7 +57,8 @@ class KeenClient(object):
     """
 
     def __init__(self, project_id, write_key=None, read_key=None,
-                 persistence_strategy=None, api_class=KeenApi, get_timeout=305, post_timeout=305):
+                 persistence_strategy=None, api_class=KeenApi, get_timeout=305, post_timeout=305
+                 master_key=None):
         """ Initializes a KeenClient object.
 
         :param project_id: the Keen IO project ID
@@ -67,6 +68,7 @@ class KeenClient(object):
         the event
         :param get_timeout: optional, the timeout on GET requests
         :param post_timeout: optional, the timeout on POST requests
+        :param master_key: a Keen IO Master API Key
         """
         super(KeenClient, self).__init__()
 
@@ -76,7 +78,8 @@ class KeenClient(object):
         # Set up an api client to be used for querying and optionally passed
         # into a default persistence strategy.
         self.api = api_class(project_id, write_key=write_key, read_key=read_key,
-                             get_timeout=get_timeout, post_timeout=post_timeout)
+                             get_timeout=get_timeout, post_timeout=post_timeout,
+                             master_key=master_key)
 
         if persistence_strategy:
             # validate the given persistence strategy

--- a/keen/client.py
+++ b/keen/client.py
@@ -57,7 +57,7 @@ class KeenClient(object):
     """
 
     def __init__(self, project_id, write_key=None, read_key=None,
-                 persistence_strategy=None, api_class=KeenApi, get_timeout=305, post_timeout=305
+                 persistence_strategy=None, api_class=KeenApi, get_timeout=305, post_timeout=305,
                  master_key=None):
         """ Initializes a KeenClient object.
 

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -20,6 +20,7 @@ class ClientTests(BaseTestCase):
         keen.project_id = None
         keen.write_key = None
         keen.read_key = None
+        keen.master_key = None
 
     def test_init(self):
         def positive_helper(project_id, **kwargs):
@@ -124,6 +125,7 @@ class ClientTests(BaseTestCase):
         keen.project_id = None
         keen.write_key = None
         keen.read_key = None
+        keen.master_key = None
         self.assert_raises(exceptions.InvalidEnvironmentError,
                            keen.add_event, "python_test", {"hello": "goodbye"})
 
@@ -137,6 +139,22 @@ class ClientTests(BaseTestCase):
         os.environ["KEEN_WRITE_KEY"] = "abcde"
         self.assert_raises(exceptions.KeenApiError,
                            keen.add_event, "python_test", {"hello": "goodbye"})
+
+    def test_set_master_key_env_var(self):
+        exp_master_key = os.environ["KEEN_MASTER_KEY"] = "abcd1234"
+        keen._initialize_client_from_environment()
+
+        self.assertEquals(exp_master_key, keen.master_key)
+        self.assertEquals(exp_master_key, keen._client.api.master_key)
+
+        del os.environ["KEEN_MASTER_KEY"]
+
+    def test_set_master_key_env_var(self):
+        exp_master_key = keen.master_key = "abcd4567"
+        keen._initialize_client_from_environment()
+
+        self.assertEquals(exp_master_key, keen.master_key)
+        self.assertEquals(exp_master_key, keen._client.api.master_key)
 
     def test_configure_through_code(self):
         keen.project_id = "123456"
@@ -230,6 +248,7 @@ class QueryTests(BaseTestCase):
         keen.project_id = None
         keen.write_key = None
         keen.read_key = None
+        keen.master_key = None
         keen._client = None
         super(QueryTests, self).tearDown()
 
@@ -355,5 +374,6 @@ if sys.version_info[0] > 3:
             keen.project_id = None
             keen.write_key = None
             keen.read_key = None
+            keen.master_key = None
             keen._client = None
             super(UnicodeTests, self).tearDown()

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -149,7 +149,7 @@ class ClientTests(BaseTestCase):
 
         del os.environ["KEEN_MASTER_KEY"]
 
-    def test_set_master_key_env_var(self):
+    def test_set_master_key_package_var(self):
         exp_master_key = keen.master_key = "abcd4567"
         keen._initialize_client_from_environment()
 

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -149,7 +149,7 @@ class ClientTests(BaseTestCase):
         self.assert_raises(exceptions.KeenApiError,
                            keen.add_event, "python_test", {"hello": "goodbye"})
 
-    def test_new_client_instance(self):
+    def test_new_client_instance(self, post):
         exp_project_id = "xxxx1234"
         exp_write_key = "yyyy4567"
         exp_read_key = "zzzz8912"
@@ -169,7 +169,7 @@ class ClientTests(BaseTestCase):
         self.assertEquals(exp_read_key, client.api.read_key)
         self.assertEquals(exp_master_key, client.api.master_key)
 
-    def test_set_master_key_env_var(self):
+    def test_set_master_key_env_var(self, post):
         exp_master_key = os.environ["KEEN_MASTER_KEY"] = "abcd1234"
         keen._initialize_client_from_environment()
 
@@ -178,7 +178,7 @@ class ClientTests(BaseTestCase):
 
         del os.environ["KEEN_MASTER_KEY"]
 
-    def test_set_master_key_package_var(self):
+    def test_set_master_key_package_var(self, post):
         exp_master_key = keen.master_key = "abcd4567"
         keen._initialize_client_from_environment()
 

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -140,6 +140,26 @@ class ClientTests(BaseTestCase):
         self.assert_raises(exceptions.KeenApiError,
                            keen.add_event, "python_test", {"hello": "goodbye"})
 
+    def test_new_client_instance(self):
+        exp_project_id = "xxxx1234"
+        exp_write_key = "yyyy4567"
+        exp_read_key = "zzzz8912"
+        exp_master_key = "abcd3456"
+        
+        # create Client instance
+        client = KeenClient(
+            project_id=exp_project_id,
+            write_key=exp_write_key,
+            read_key=exp_read_key,
+            master_key=exp_master_key
+        )
+
+        # assert values
+        self.assertEquals(exp_project_id, client.api.project_id)
+        self.assertEquals(exp_write_key, client.api.write_key)
+        self.assertEquals(exp_read_key, client.api.read_key)
+        self.assertEquals(exp_master_key, client.api.master_key)
+
     def test_set_master_key_env_var(self):
         exp_master_key = os.environ["KEEN_MASTER_KEY"] = "abcd1234"
         keen._initialize_client_from_environment()


### PR DESCRIPTION
It would be convenient to store and/or access the Master API Key using `keen.master_key` or `KEEN_MASTER_KEY` or optionally when creating an instance of `KeenClient()` with

```python
    from keen.client import KeenClient

    client = KeenClient(
        project_id="xxxx",
        write_key="yyyy",
        read_key="zzzz",
        master_key="abcd"
    )
```
In this pull request are 4 commits : 

- https://github.com/ruleant/KeenClient-Python/commit/9edbf53c8f872d90d99ed3887e30aefa5c557c3e : importing `KEEN_MASTER_KEY`
- https://github.com/ruleant/KeenClient-Python/commit/afab4935fe9d736d9626e7fc5ee8ba29026291a2 : (optional) define `master_key` in the KeenApi constructor
- https://github.com/ruleant/KeenClient-Python/commit/2c617e6395343843d8fea4332edaf57a2a452852 : (optional) define `master_key` in the KeenClient constructor
- https://github.com/ruleant/KeenClient-Python/commit/c3a6da471acadf380166fca0e9a0fc13c155740a : (optional) create KeenClient instance with `master_key` parameter

I'm not sure if it is needed to have `master_key` defined in `KeenClient` or `KeenApi`, it surely isn't needed to use the API, but I've added those commits for completeness, I can remove them from this pull request later on.

But I feel it makes sense to have `keen.master_key` defined.
`scoped_keys.encrypt()` could use the `keen.master_key` if parameter `api_key` is not defined?

What do you think?