### PR TITLE
Update setup

### DIFF
--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -125,8 +125,11 @@ class ClientTests(BaseTestCase):
         self.assert_raises(requests.Timeout, keen.add_events, {"python_test": [{"hello": "goodbye"}]})
 
     def test_environment_variables(self, post):
-        post.return_value = MockedFailedRequest(status_code=401,
-                     json_response={"message": "authorization error", "error_code": 401})
+        post.return_value = MockedFailedRequest(
+            status_code=401,
+            # "message" is the description, "error_code" is the name of the class.
+            json_response={"message": "authorization error", "error_code": "AdminOnlyEndpointError"},
+        )
         # try addEvent w/out having environment variables
         keen._client = None
         keen.project_id = None
@@ -154,7 +157,7 @@ class ClientTests(BaseTestCase):
         exp_write_key = "yyyy4567"
         exp_read_key = "zzzz8912"
         exp_master_key = "abcd3456"
-        
+
         # create Client instance
         client = KeenClient(
             project_id=exp_project_id,
@@ -194,7 +197,8 @@ class ClientTests(BaseTestCase):
         client = KeenClient(project_id="123456", read_key=None, write_key="abcdef")
         with patch("requests.Session.post") as post:
             post.return_value = MockedFailedRequest(
-                status_code=401, json_response={"message": "authorization error", "error_code": 401}
+                status_code=401,
+                json_response={"message": "authorization error", "error_code": "AdminOnlyEndpointError"},
             )
             self.assert_raises(exceptions.KeenApiError,
                                client.add_event, "python_test", {"hello": "goodbye"})

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 # from distutils.core import setup
 from setuptools import setup, find_packages
+from pip.req import parse_requirements
 import sys
 
 try:
@@ -9,7 +10,14 @@ try:
 except ImportError:
     pass
 
+# parse_requirements() returns generator of pip.req.InstallRequirement objects
+install_reqs = parse_requirements("./requirements.txt")
 tests_require = ['nose']
+
+# reqs is a list of requirement
+# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
+reqs = [str(ir.req) for ir in install_reqs]
+
 
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')
@@ -26,7 +34,7 @@ setup(
     author_email="team@keen.io",
     url="https://github.com/keenlabs/KeenClient-Python",
     packages=["keen"],
-    install_requires=["requests", "pycrypto", "Padding"],
+    install_requires=reqs,
     tests_require=tests_require,
     test_suite='nose.collector',
 )


### PR DESCRIPTION
 `Pip install keen` should now grab the package versions specified in requirements.txt regardless of whether packages exist in some version prior to installing keen.