### PR TITLE
Updated setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ The Python client enables you to create [Scoped Keys](https://keen.io/docs/secur
 
 ### Changelog
 
+##### 0.3.10
++ Fixed requirements in `setup.py`
++ Updated test inputs and documentation.
+
 ##### 0.3.9
 + Added ```master_key``` parameter.
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ if 'nosetests' in sys.argv[1:]:
 
 setup(
     name="keen",
-    version="0.3.9",
+    version="0.3.10",
     description="Python Client for Keen IO",
     author="Keen IO",
     author_email="team@keen.io",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 
 # from distutils.core import setup
 from setuptools import setup, find_packages
+from pip.req import parse_requirements
 import sys
 
 try:
@@ -9,7 +10,13 @@ try:
 except ImportError:
     pass
 
+# parse_requirements() returns generator of pip.req.InstallRequirement objects
+install_reqs = parse_requirements("./requirements.txt")
 tests_require = ['nose']
+
+# reqs is a list of requirement
+# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
+reqs = [str(ir.req) for ir in install_reqs]
 
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')
@@ -26,7 +33,7 @@ setup(
     author_email="team@keen.io",
     url="https://github.com/keenlabs/KeenClient-Python",
     packages=["keen"],
-    install_requires=["requests", "pycrypto", "Padding"],
+    install_requires=reqs,
     tests_require=tests_require,
     test_suite='nose.collector',
 )


### PR DESCRIPTION
`Pip install keen` should now grab the package versions specified in `requirements.txt` regardless of whether packages exist in some version prior to installing keen.