### PR TITLE
changed client to keen

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can also configure unique client instances as follows:
 ```python
     from keen.client import KeenClient
 
-    client = KeenClient(
+    keen = KeenClient(
         project_id="xxxx",
         write_key="yyyy",
         read_key="zzzz",


### PR DESCRIPTION
The rest of the README uses the variable `keen` to refer to the client, however, when you initialize the client in the docs, it's called `client`.  This fixes it to be consistent throughout.

:heart: @faridasabry2 & @nquinlan at Hack@Smith :smiley: