### PR TITLE
Add example of using unique client instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Once you've set `KEEN_PROJECT_ID` and `KEEN_WRITE_KEY`, sending events is simple
     })
 ```
 
+Or if using unique client instances:
+
+```python
+    client.add_event(...)
+```
+
 ##### Send Batch Events to Keen IO
 
 You can upload Events in a batch, like so:


### PR DESCRIPTION
After following the readme through setting up a unique client instance, I thought it was confusing that all of the call examples were directly to `keen.foo(...)` vs `client.foo(...)`.

I thought it'd be helpful to be explicit here.