### PR TITLE
closes #31 which adds a generic check for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,9 @@ The Python client enables you to create [Scoped Keys](https://keen.io/docs/secur
 
 ### Changelog
 
+##### 0.3.15
++ Added better error handling to surface all errors from HTTP API calls 
+
 ##### 0.3.14
 + Added compatibility for pip 1.0
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,6 @@ The Python client enables you to create [Scoped Keys](https://keen.io/docs/secur
 + Added compatibility for pip 1.0
 
 ##### 0.3.13
-+ Added better error handling to surface all errors from HTTP API calls 
-
-##### 0.3.13
 + Added compatibility for pip < 1.5.6
 
 ##### 0.3.12

--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ The Python client enables you to create [Scoped Keys](https://keen.io/docs/secur
 ### Changelog
 
 ##### 0.3.13
++ Added better error handling to surface all errors from HTTP API calls 
+
+##### 0.3.13
 + Added compatibility for pip < 1.5.6
 
 ##### 0.3.12

--- a/keen/api.py
+++ b/keen/api.py
@@ -172,5 +172,5 @@ class KeenApi(object):
             try:
                 error = res.json()
             except json.JSONDecodeError:
-                error = {'message': 'The API did not respond with JSON, but: "{0}"'.format(res.text[:1000])', "error_code": "InvalidResponseFormat"}
+                error = {'message': 'The API did not respond with JSON, but: "{0}"'.format(res.text[:1000]), "error_code": "InvalidResponseFormat"}
             raise exceptions.KeenApiError(error)

--- a/keen/api.py
+++ b/keen/api.py
@@ -113,9 +113,7 @@ class KeenApi(object):
         headers = {"Content-Type": "application/json", "Authorization": self.write_key}
         payload = event.to_json()
         response = self.fulfill(HTTPMethods.POST, url, data=payload, headers=headers, timeout=self.post_timeout)
-        if response.status_code != 201:
-            error = response.json()
-            raise exceptions.KeenApiError(error)
+        self.error_handling(response)
 
     def post_events(self, events):
 
@@ -136,9 +134,7 @@ class KeenApi(object):
         headers = {"Content-Type": "application/json", "Authorization": self.write_key}
         payload = json.dumps(events)
         response = self.fulfill(HTTPMethods.POST, url, data=payload, headers=headers, timeout=self.post_timeout)
-        if response.status_code != 200:
-            error = response.json()
-            raise exceptions.KeenApiError(error)
+        self.error_handling(response)
 
     def query(self, analysis_type, params):
         """
@@ -158,8 +154,17 @@ class KeenApi(object):
         headers = {"Authorization": self.read_key}
         payload = params
         response = self.fulfill(HTTPMethods.GET, url, params=payload, headers=headers, timeout=self.get_timeout)
-        if response.status_code != 200:
-            error = response.json()
-            raise exceptions.KeenApiError(error)
+        self.error_handling(response)
 
         return response.json()["result"]
+
+    def error_handling(self, res):
+        """
+        Helper function to do the error handling 
+
+        :params res: the response from a request
+        """
+        # making the error handling generic so if an error_code exists, we raise the error
+        if res.json().get("error_code"):
+            error = res.json()
+            raise exceptions.KeenApiError(error)

--- a/keen/api.py
+++ b/keen/api.py
@@ -10,6 +10,9 @@ from requests.packages.urllib3.poolmanager import PoolManager
 # keen exceptions
 from keen import exceptions
 
+# json
+from requests.compat import json
+
 
 __author__ = 'dkador'
 
@@ -166,5 +169,8 @@ class KeenApi(object):
         """
         # making the error handling generic so if an status_code starting with 2 doesn't exist, we raise the error
         if res.status_code // 100 != 2:
-            error = res.json()
+            try:
+                error = res.json()
+            except json.JSONDecodeError:
+                error = {'message': 'The API did not respond with JSON, but: "{0}"'.format(res.text[:1000])', "error_code": "InvalidResponseFormat"}
             raise exceptions.KeenApiError(error)

--- a/keen/api.py
+++ b/keen/api.py
@@ -165,6 +165,6 @@ class KeenApi(object):
         :params res: the response from a request
         """
         # making the error handling generic so if an error_code exists, we raise the error
-        if res.json().get("error_code"):
+        if res.status_code/100 != 2:
             error = res.json()
             raise exceptions.KeenApiError(error)

--- a/keen/api.py
+++ b/keen/api.py
@@ -164,7 +164,7 @@ class KeenApi(object):
 
         :params res: the response from a request
         """
-        # making the error handling generic so if an status_code starting with 2 exists, we raise the error
+        # making the error handling generic so if an status_code starting with 2 doesn't exist, we raise the error
         if res.status_code/100 != 2:
             error = res.json()
             raise exceptions.KeenApiError(error)

--- a/keen/api.py
+++ b/keen/api.py
@@ -164,7 +164,7 @@ class KeenApi(object):
 
         :params res: the response from a request
         """
-        # making the error handling generic so if an error_code exists, we raise the error
+        # making the error handling generic so if an status_code starting with 2 exists, we raise the error
         if res.status_code/100 != 2:
             error = res.json()
             raise exceptions.KeenApiError(error)


### PR DESCRIPTION
- modified the api.py to have a seperate function for error_handling
- added a check to find a generic error (by looking for the error_code in response)
- if error_code is found, it raises whatever error is in the response