### PR TITLE
Allow pycrypto to float on 2.6, disallow requests past 2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Padding>=0.4
-pycrypto==2.6
-requests>=2.5
+pycrypto>=2.6,<2.7
+requests>=2.5,<3.0


### PR DESCRIPTION
Addresses #64.