### PR TITLE
Added “all_key” param + funnel test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,13 @@ Or if using unique client instances:
 ##### Send Batch Events to Keen IO
 
 You can upload Events in a batch, like so:
-    
+
 ```python
     # uploads 4 events total - 2 to the "sign_ups" collection and 2 to the "purchases" collection
     keen.add_events({
         "sign_ups": [
             { "username": "nameuser1" },
-            { "username": "nameuser2" } 
+            { "username": "nameuser2" }
         ],
         "purchases": [
             { "price": 5 },
@@ -112,6 +112,10 @@ Here are some examples of querying.  Let's assume you've added some events to th
     }
     keen.funnel([step1, step2], timeframe="today") # => [2039, 201]
 ```
+
+To return the full API response (as opposed to the singular "result" key), set `all_keys=True`.
+
+For example, `keen.funnel([step1, step2], all_keys=True)` would return "result", "actors" and "steps" keys.
 
 ##### Delete Events
 
@@ -198,8 +202,12 @@ The Python client enables you to create [Scoped Keys](https://keen.io/docs/secur
 
 ### Changelog
 
+##### 0.3.16
++ Added `all_keys` parameter which allows users to expose all keys in query response.
++ Added `delete_events` method.
+
 ##### 0.3.15
-+ Added better error handling to surface all errors from HTTP API calls 
++ Added better error handling to surface all errors from HTTP API calls.
 
 ##### 0.3.14
 + Added compatibility for pip 1.0

--- a/keen/__init__.py
+++ b/keen/__init__.py
@@ -33,11 +33,11 @@ def _initialize_client_from_environment():
 
 def add_event(event_collection, body, timestamp=None):
     """ Adds an event.
-    
+
     Depending on the persistence strategy of the client,
     this will either result in the event being uploaded to Keen
     immediately or will result in saving the event to some local cache.
-    
+
     :param event_collection: the name of the collection to insert the
     event to
     :param body: dict, the body of the event to insert the event to
@@ -49,11 +49,11 @@ def add_event(event_collection, body, timestamp=None):
 
 def add_events(events):
     """ Adds a batch of events.
-    
+
     Depending on the persistence strategy of the client,
     this will either result in the event being uploaded to Keen
     immediately or will result in saving the event to some local cache.
-    
+
     :param events: dictionary of events
     """
     _initialize_client_from_environment()
@@ -62,7 +62,7 @@ def add_events(events):
 
 def generate_image_beacon(event_collection, body, timestamp=None):
     """ Generates an image beacon URL.
-    
+
     :param event_collection: the name of the collection to insert the
     event to
     :param body: dict, the body of the event to insert the event to
@@ -355,7 +355,7 @@ def extraction(event_collection, timeframe=None, timezone=None, filters=None, la
                               filters=filters, latest=latest, email=email, property_names=property_names)
 
 
-def funnel(steps, timeframe=None, timezone=None, max_age=None):
+def funnel(*args, **kwargs):
     """ Performs a Funnel query
 
     Returns an object containing the results for each step of the funnel.
@@ -372,7 +372,7 @@ def funnel(steps, timeframe=None, timezone=None, max_age=None):
 
     """
     _initialize_client_from_environment()
-    return _client.funnel(steps=steps, timeframe=timeframe, timezone=timezone, max_age=max_age)
+    return _client.funnel(*args, **kwargs)
 
 
 def multi_analysis(event_collection, analyses, timeframe=None, interval=None,

--- a/keen/api.py
+++ b/keen/api.py
@@ -140,7 +140,7 @@ class KeenApi(object):
         response = self.fulfill(HTTPMethods.POST, url, data=payload, headers=headers, timeout=self.post_timeout)
         self.error_handling(response)
 
-    def query(self, analysis_type, params):
+    def query(self, analysis_type, params, all_keys=False):
         """
         Performs a query using the Keen IO analysis API.  A read key must be set first.
 
@@ -160,7 +160,12 @@ class KeenApi(object):
         response = self.fulfill(HTTPMethods.GET, url, params=payload, headers=headers, timeout=self.get_timeout)
         self.error_handling(response)
 
-        return response.json()["result"]
+        response = response.json()
+
+        if not all_keys:
+            response = response["result"]
+
+        return response
 
     def delete_events(self, event_collection, params):
         """

--- a/keen/client.py
+++ b/keen/client.py
@@ -466,7 +466,7 @@ class KeenClient(object):
                                  filters=filters, latest=latest, email=email, property_names=property_names)
         return self.api.query("extraction", params)
 
-    def funnel(self, steps, timeframe=None, timezone=None, max_age=None):
+    def funnel(self, steps, timeframe=None, timezone=None, max_age=None, all_keys=False):
         """ Performs a Funnel query
 
         Returns an object containing the results for each step of the funnel.
@@ -480,10 +480,17 @@ class KeenClient(object):
         and interval in seconds
         :param max_age: an integer, greater than 30 seconds, the maximum 'staleness' you're
         willing to trade for increased query performance, in seconds
+        :all_keys: set to true to return all keys on response (i.e. "result", "actors", "steps")
 
         """
-        params = self.get_params(steps=steps, timeframe=timeframe, timezone=timezone, max_age=max_age)
-        return self.api.query("funnel", params)
+        params = self.get_params(
+            steps=steps,
+            timeframe=timeframe,
+            timezone=timezone,
+            max_age=max_age,
+        )
+
+        return self.api.query("funnel", params, all_keys=all_keys)
 
     def multi_analysis(self, event_collection, analyses, timeframe=None, interval=None, timezone=None, filters=None,
                        group_by=None, max_age=None):

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -466,7 +466,7 @@ class DeleteTests(BaseTestCase):
         super(DeleteTests, self).tearDown()
 
     def test_delete_events(self, delete):
-        delete.return_value = MockedRequest(status_code=204, json_response=[])
+        delete.return_value = MockedResponse(status_code=204, json_response=[])
         # Assert that the mocked delete function is called the way we expect.
         keen.delete_events("foo", filters=[{"property_name": 'username', "operator": 'eq', "property_value": 'Bob'}])
         # Check that the URL is generated correctly.

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -404,8 +404,8 @@ class QueryTests(BaseTestCase):
 
         resp = keen.funnel([1, 2], all_keys=True)
         self.assertEquals(type(resp), dict)
-        self.assertIn("actors", resp)
-        self.assertIn("random_key", resp)
+        self.assertTrue("actors" in resp)
+        self.assertTrue("random_key" in resp)
 
     def test_group_by(self, get):
         get.return_value = self.LIST_RESPONSE

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -14,16 +14,16 @@ import sys
 __author__ = 'dkador'
 
 
-class MockedRequest(object):
+class MockedResponse(object):
     def __init__(self, status_code, json_response):
         self.status_code = status_code
         self.json_response = json_response
 
     def json(self):
-        return {"result": self.json_response}
+        return self.json_response
 
 
-class MockedFailedRequest(MockedRequest):
+class MockedFailedResponse(MockedResponse):
     def json(self):
         return self.json_response
 
@@ -31,10 +31,9 @@ class MockedFailedRequest(MockedRequest):
 @patch("requests.Session.post")
 class ClientTests(BaseTestCase):
 
-    SINGLE_ADD_RESPONSE = MockedRequest(status_code=201, json_response={"hello": "goodbye"})
+    SINGLE_ADD_RESPONSE = MockedResponse(status_code=201, json_response={"result": {"hello": "goodbye"}})
 
-    MULTI_ADD_RESPONSE = MockedRequest(status_code=200, json_response={"hello": "goodbye"})
-
+    MULTI_ADD_RESPONSE = MockedResponse(status_code=200, json_response={"result": {"hello": "goodbye"}})
 
     def setUp(self):
         super(ClientTests, self).setUp()
@@ -125,7 +124,7 @@ class ClientTests(BaseTestCase):
         self.assert_raises(requests.Timeout, keen.add_events, {"python_test": [{"hello": "goodbye"}]})
 
     def test_environment_variables(self, post):
-        post.return_value = MockedFailedRequest(
+        post.return_value = MockedFailedResponse(
             status_code=401,
             # "message" is the description, "error_code" is the name of the class.
             json_response={"message": "authorization error", "error_code": "AdminOnlyEndpointError"},
@@ -185,7 +184,7 @@ class ClientTests(BaseTestCase):
         exp_write_key = os.environ["KEEN_WRITE_KEY"] = "yyyy8901"
         exp_read_key = os.environ["KEEN_READ_KEY"] = "zzzz2345"
         exp_master_key = os.environ["KEEN_MASTER_KEY"] = "abcd1234"
-        
+
         keen._initialize_client_from_environment()
 
         # test values
@@ -209,7 +208,7 @@ class ClientTests(BaseTestCase):
         exp_write_key = keen.write_key = "vvvv8901"
         exp_read_key = keen.read_key = "wwwww2345"
         exp_master_key = keen.master_key = "abcd4567"
-        
+
         keen._initialize_client_from_environment()
 
         # test values
@@ -230,7 +229,7 @@ class ClientTests(BaseTestCase):
         # force client to reinitialize
         client = KeenClient(project_id="123456", read_key=None, write_key="abcdef")
         with patch("requests.Session.post") as post:
-            post.return_value = MockedFailedRequest(
+            post.return_value = MockedFailedResponse(
                 status_code=401,
                 json_response={"message": "authorization error", "error_code": "AdminOnlyEndpointError"},
             )
@@ -291,10 +290,10 @@ class ClientTests(BaseTestCase):
 @patch("requests.Session.get")
 class QueryTests(BaseTestCase):
 
-    INT_RESPONSE = MockedRequest(status_code=200, json_response=2)
+    INT_RESPONSE = MockedResponse(status_code=200, json_response={"result": 2})
 
-    LIST_RESPONSE = MockedRequest(
-        status_code=200, json_response=[{"value": {"total": 1}}, {"value": {"total": 2}}])
+    LIST_RESPONSE = MockedResponse(
+        status_code=200, json_response={"result": [{"value": {"total": 1}}, {"value": {"total": 2}}]})
 
     def setUp(self):
         super(QueryTests, self).setUp()
@@ -380,18 +379,33 @@ class QueryTests(BaseTestCase):
 
     def test_funnel(self, get):
         get.return_value = self.LIST_RESPONSE
+
         step1 = {
-            "event_collection": "query test",
-            "actor_property": "number",
+            "event_collection": "signed up",
+            "actor_property": "visitor.guid",
             "timeframe": "today"
         }
         step2 = {
-            "event_collection": "step2",
-            "actor_property": "number",
+            "event_collection": "completed profile",
+            "actor_property": "user.guid",
             "timeframe": "today"
         }
+
         resp = keen.funnel([step1, step2])
         self.assertEqual(type(resp), list)
+
+    def test_funnel_return_all_keys(self, get):
+        get.return_value = MockedResponse(status_code=200, json_response={
+            "result": [],
+            "actors": [],
+            "random_key": [],
+            "steps": []
+        })
+
+        resp = keen.funnel([1, 2], all_keys=True)
+        self.assertIsInstance(resp, dict)
+        self.assertIn("actors", resp)
+        self.assertIn("random_key", resp)
 
     def test_group_by(self, get):
         get.return_value = self.LIST_RESPONSE
@@ -471,7 +485,7 @@ if sys.version_info[0] < 3:
             api_key = unicode("2e79c6ec1d0145be8891bf668599c79a")
             keen.write_key = unicode(api_key)
 
-        @patch("requests.Session.post", MagicMock(return_value=MockedRequest(status_code=201, json_response=[0, 1, 2])))
+        @patch("requests.Session.post", MagicMock(return_value=MockedResponse(status_code=201, json_response=[0, 1, 2])))
         def test_add_event_with_unicode(self):
             keen.add_event(unicode("unicode test"), {unicode("number"): 5, "string": unicode("foo")})
 

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -403,7 +403,7 @@ class QueryTests(BaseTestCase):
         })
 
         resp = keen.funnel([1, 2], all_keys=True)
-        self.assertIsInstance(resp, dict)
+        self.assertEquals(type(resp), dict)
         self.assertIn("actors", resp)
         self.assertIn("random_key", resp)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name="keen",
-    version="0.3.15",
+    version="0.3.16",
     description="Python Client for Keen IO",
     author="Keen IO",
     author_email="team@keen.io",


### PR DESCRIPTION
Added "all_keys" param so response can include all keys (i.e. "result", "actors", "steps"). 

This PR should address #68 