### PR TITLE
correctly import urllib3.poolmanager

### DIFF
--- a/keen/api.py
+++ b/keen/api.py
@@ -5,7 +5,7 @@ import ssl
 # requests
 import requests
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+from urllib3.poolmanager import PoolManager
 
 # keen exceptions
 from keen import exceptions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Padding>=0.4
 pycrypto>=2.6,<2.7
 requests>=2.5,<3.0
+urllib3


### PR DESCRIPTION
Even with dependencies (requests == 2.7) correctly installed an error message appeared :

```
  File "/usr/local/lib/python2.7/dist-packages/keen/api.py", line 8, in <module>
    from requests.packages.urllib3.poolmanager import PoolManager
ImportError: No module named packages.urllib3.poolmanager
```

This solution was suggested in a similar bug report of another python project : https://github.com/omab/python-social-auth/issues/617#issuecomment-101398379