### PR TITLE
Except ValueError instead of JSONDecodeError

### DIFF
--- a/keen/api.py
+++ b/keen/api.py
@@ -239,7 +239,7 @@ class KeenApi(object):
         if res.status_code // 100 != 2:
             try:
                 error = res.json()
-            except json.JSONDecodeError:
+            except ValueError:
                 error = {
                     'message': 'The API did not respond with JSON, but: "{0}"'.format(res.text[:1000]),
                     "error_code": "InvalidResponseFormat"


### PR DESCRIPTION
The built-in Python `json` module doesn't appear to have a `JSONDecodeError` - instead, the `.json()` method raises a `ValueError` on bad json.