### PR TITLE
Saved queries support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 # command to install dependencies
-install: "pip install -r requirements.txt --use-mirrors"
+install: "pip install -r requirements.txt"
 # command to run tests
 script: "python setup.py test"

--- a/README.md
+++ b/README.md
@@ -144,6 +144,30 @@ You'll need to set your master_key.
 
 See below for more options.
 
+##### Saved Queries
+You can manage your saved queries from the Keen python client.
+
+```python
+# Create a saved query
+keen.saved_queries.create("name", saved_query_attributes)
+
+# Get all saved queries
+keen.saved_queries.all
+
+# Get one saved query
+keen.saved_queries.get("saved-query-slug")
+
+# Get saved query with results
+keen.saved_queries.results("saved-query-slug")
+
+# Update a saved query
+saved_query_attributes = { refresh_rate: 14400 }
+keen.saved_queries.update("saved-query-slug", saved_query_attributes)
+
+# Delete a saved query
+keen.saved_queries.delete("saved-query-slug")
+```
+
 ##### Overwriting event timestamps
 
 Two time-related properties are included in your event automatically. The properties “keen.timestamp” and “keen.created_at” are set at the time your event is recorded. You have the ability to overwrite the keen.timestamp property. This could be useful, for example, if you are backfilling historical data. Be sure to use [ISO-8601 Format](https://keen.io/docs/event-data-modeling/event-data-intro/#iso-8601-format).
@@ -212,6 +236,13 @@ The Python client enables you to create [Scoped Keys](https://keen.io/docs/secur
 ```
 
 `write_key` and `read_key` now contain scoped keys based on your master API key.
+
+### Testing
+
+To run tests:
+```
+python setup.py tests
+```
 
 ### Changelog
 

--- a/keen/client.py
+++ b/keen/client.py
@@ -2,7 +2,7 @@ import base64
 import copy
 import json
 import sys
-from keen import persistence_strategies, exceptions
+from keen import persistence_strategies, exceptions, saved_queries
 from keen.api import KeenApi
 from keen.persistence_strategies import BasePersistenceStrategy
 
@@ -97,6 +97,7 @@ class KeenClient(object):
         self.persistence_strategy = persistence_strategy
         self.get_timeout = get_timeout
         self.post_timeout = post_timeout
+        self.saved_queries = saved_queries.SavedQueriesInterface(project_id, master_key, read_key)
 
     if sys.version_info[0] < 3:
         @staticmethod

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -1,0 +1,114 @@
+from keen.api import KeenApi
+from keen import exceptions
+
+class SavedQueriesInterface:
+
+    def __init__(self, project_id, master_key, read_key):
+        self.project_id = project_id
+        self.master_key = master_key
+        self.read_key = read_key
+
+    def all(self):
+        """
+        Gets all saved queries for a project from the Keen IO API.
+        Master key must be set.
+        """
+        keen_api = KeenApi(self.project_id, master_key=self.master_key)
+        self._check_for_master_key()
+        url = "{0}/{1}/projects/{2}/queries/saved".format(
+            keen_api.base_url, keen_api.api_version, self.project_id
+        )
+        response = keen_api.fulfill("get", url, headers=self._headers())
+
+        return response.json()
+
+    def get(self, query_name):
+        """
+        Gets a single saved query for a project from the Keen IO API given a
+        query name.
+        Master key must be set.
+        """
+        keen_api = KeenApi(self.project_id, master_key=self.master_key)
+        self._check_for_master_key()
+        url = "{0}/{1}/projects/{2}/queries/saved/{3}".format(
+            keen_api.base_url, keen_api.api_version, self.project_id, query_name
+        )
+        response = keen_api.fulfill("get", url, headers=self._headers())
+        keen_api._error_handling(response)
+
+        return response.json()
+
+    def results(self, query_name):
+        """
+        Gets a single saved query with a 'result' object for a project from thei
+        Keen IO API given a query name.
+        Read or Master key must be set.
+        """
+        keen_api = KeenApi(self.project_id, master_key=self.master_key)
+        self._check_for_master_or_read_key()
+        url = "{0}/{1}/projects/{2}/queries/saved/{3}/result".format(
+            keen_api.base_url, keen_api.api_version, self.project_id, query_name
+        )
+        key = self.master_key if self.master_key else self.read_key
+        response = keen_api.fulfill("get", url, headers={"Authorization": key })
+        keen_api._error_handling(response)
+
+        return response.json()
+
+    def create(self, query_name, saved_query):
+        """
+        Creates the saved query via a PUT request to Keen IO Saved Query endpoint. Master key must be set.
+        """
+        keen_api = KeenApi(self.project_id, master_key=self.master_key)
+        self._check_for_master_key()
+        url = "{0}/{1}/projects/{2}/queries/saved/{3}".format(
+            keen_api.base_url, keen_api.api_version, self.project_id, query_name
+        )
+        response = keen_api.fulfill(
+            "put", url, headers=self._headers(), data=saved_query
+        )
+        keen_api._error_handling(response)
+
+        return response.json()
+
+    def update(self, query_name, saved_query):
+        """
+        Updates the saved query via a PUT request to Keen IO Saved Query
+        endpoint.
+        Master key must be set.
+        """
+        return self.create(query_name, saved_query)
+
+    def delete(self, query_name):
+        """
+        Deletes a saved query from a project with a query name.
+        Master key must be set.
+        """
+        keen_api = KeenApi(self.project_id, master_key=self.master_key)
+        self._check_for_master_key()
+        url = "{0}/{1}/projects/{2}/queries/saved/{3}".format(
+            keen_api.base_url, keen_api.api_version, self.project_id, query_name
+        )
+        response = keen_api.fulfill("delete", url, headers=self._headers())
+        keen_api._error_handling(response)
+
+        return True
+
+    def _headers(self):
+        return {"Authorization": self.master_key}
+
+    def _check_for_master_key(self):
+        if not self.master_key:
+            raise exceptions.InvalidEnvironmentError(
+                "The Keen IO API requires a master key to perform this operation on saved queries. "
+                "Please set a 'master_key' when initializing the "
+                "KeenApi object."
+            )
+
+    def _check_for_master_or_read_key(self):
+        if not (self.read_key or self.master_key):
+            raise exceptions.InvalidEnvironmentError(
+                "The Keen IO API requires a read key or master key to perform this operation on saved queries. "
+                "Please set a 'read_key' or 'master_key' when initializing the "
+                "KeenApi object."
+            )

--- a/keen/tests/saved_query_tests.py
+++ b/keen/tests/saved_query_tests.py
@@ -1,0 +1,150 @@
+from keen.tests.base_test_case import BaseTestCase
+from keen.client import KeenClient
+from keen import exceptions
+
+import responses
+
+class SavedQueryTests(BaseTestCase):
+
+    def setUp(self):
+        super(SavedQueryTests, self).setUp()
+        self.exp_project_id = "xxxx1234"
+        exp_master_key = "abcd3456"
+        self.client = KeenClient(
+            project_id=self.exp_project_id,
+            master_key=exp_master_key
+        )
+
+    def test_get_all_saved_queries_keys(self):
+        client = KeenClient(project_id="123123")
+        self.assertRaises(
+            exceptions.InvalidEnvironmentError, client.saved_queries.all
+        )
+
+    @responses.activate
+    def test_get_all_saved_queries(self):
+        saved_queries_response = [
+            { "query_name": "first-saved-query", "query": {} },
+            { "query_name": "second-saved-query", "query": {} }
+        ]
+        url = "{0}/{1}/projects/{2}/queries/saved".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+        responses.add(
+            responses.GET, url, status=200, json=saved_queries_response
+        )
+
+        all_saved_queries = self.client.saved_queries.all()
+
+        self.assertEquals(all_saved_queries, saved_queries_response)
+
+    def test_get_one_saved_query_keys(self):
+        client = KeenClient(project_id="123123")
+        self.assertRaises(
+            exceptions.InvalidEnvironmentError,
+            lambda: client.saved_queries.get("saved-query-name")
+        )
+
+    @responses.activate
+    def test_get_one_saved_query(self):
+        saved_queries_response = {
+            "query_name": "saved-query-name"
+        }
+        url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+        responses.add(
+            responses.GET, url, status=200, json=saved_queries_response
+        )
+
+        saved_query = self.client.saved_queries.get("saved-query-name")
+
+        self.assertEquals(saved_query, saved_queries_response)
+
+    def test_create_saved_query_master_key(self):
+        client = KeenClient(project_id="123123")
+        self.assertRaises(
+            exceptions.InvalidEnvironmentError,
+            lambda: client.saved_queries.create("saved-query-name", {})
+        )
+
+    @responses.activate
+    def test_create_saved_query(self):
+        saved_queries_response = {
+            "query_name": "saved-query-name"
+        }
+        url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+        responses.add(
+            responses.PUT, url, status=201, json=saved_queries_response
+        )
+
+        saved_query = self.client.saved_queries.create("saved-query-name", saved_queries_response)
+
+        self.assertEquals(saved_query, saved_queries_response)
+
+    @responses.activate
+    def test_update_saved_query(self):
+        saved_queries_response = {
+            "query_name": "saved-query-name"
+        }
+        url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+        responses.add(
+            responses.PUT, url, status=200, json=saved_queries_response
+        )
+
+        saved_query = self.client.saved_queries.update("saved-query-name", saved_queries_response)
+
+        self.assertEquals(saved_query, saved_queries_response)
+
+    def test_delete_saved_query_master_key(self):
+        client = KeenClient(project_id="123123", read_key="123123")
+        self.assertRaises(
+            exceptions.InvalidEnvironmentError,
+            lambda: client.saved_queries.delete("saved-query-name")
+        )
+
+    @responses.activate
+    def test_delete_saved_query(self):
+        url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+        responses.add(
+            responses.DELETE, url, status=204, json=""
+        )
+
+        response = self.client.saved_queries.delete("saved-query-name")
+
+        self.assertEquals(response, True)
+
+    @responses.activate
+    def test_saved_query_results(self):
+        saved_queries_response = {
+            "query_name": "saved-query-name",
+            "results": {}
+        }
+        url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name/result".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+        responses.add(
+            responses.GET, url, status=209, json=saved_queries_response
+        )
+
+        response = self.client.saved_queries.results("saved-query-name")
+
+        self.assertEquals(response, saved_queries_response)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ reqs_file = open(os.path.join(setup_path, 'requirements.txt'), 'r')
 reqs = reqs_file.readlines()
 reqs_file.close()
 
-tests_require = ['nose', 'mock']
+tests_require = ['nose', 'mock', 'responses']
 
 if sys.version_info < (2, 7):
     tests_require.append('unittest2')


### PR DESCRIPTION
* allow user to get, create, update, and delete saved queries from keen client
* use `Responses` library for http mocking
* move all private methods in `keen/api.py` to bottom of file
* minor refactoring in `keen/api.py`
* Update README with testing instructions
* Add python3.4 to travis.yml