### PR TITLE
Added status code to JSON parse error response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,9 @@ python setup.py tests
 
 ### Changelog
 
+##### 0.3.23
++ Added status code to JSON parse error response
+
 ##### 0.3.22
 + Added support for python 3.5
 

--- a/keen/api.py
+++ b/keen/api.py
@@ -199,8 +199,7 @@ class KeenApi(object):
 
         """
         self._check_for_master_key()
-        url = "{0}/{1}/projects/{2}/events".format(self.base_url, self.api_version,
-                                                       self.project_id)
+        url = "{0}/{1}/projects/{2}/events".format(self.base_url, self.api_version, self.project_id)
         headers = {"Authorization": self.master_key}
         response = self.fulfill(HTTPMethods.GET, url, headers=headers, timeout=self.get_timeout)
         self._error_handling(response)
@@ -219,8 +218,8 @@ class KeenApi(object):
                 error = res.json()
             except ValueError:
                 error = {
-                    'message': 'The API did not respond with JSON, but: "{0}"'.format(res.text[:1000]),
-                    "error_code": "InvalidResponseFormat"
+                    "message": "The API did not respond with JSON, but: {}".format(res.text[:1000]),
+                    "error_code": "{}".format(res.status_code)
                 }
             raise exceptions.KeenApiError(error)
 

--- a/keen/api.py
+++ b/keen/api.py
@@ -218,8 +218,8 @@ class KeenApi(object):
                 error = res.json()
             except ValueError:
                 error = {
-                    "message": "The API did not respond with JSON, but: {}".format(res.text[:1000]),
-                    "error_code": "{}".format(res.status_code)
+                    "message": "The API did not respond with JSON, but: {0}".format(res.text[:1000]),
+                    "error_code": "{0}".format(res.status_code)
                 }
             raise exceptions.KeenApiError(error)
 

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -136,11 +136,16 @@ class ClientTests(BaseTestCase):
             text="test error text"
         )
 
-        with self.assert_raises(exceptions.KeenApiError) as cm:
-            keen.add_event("python_test", {"hello": "goodbye"})
+        exception = None
 
-        self.assertIn(post.return_value.text, str(cm.exception))
-        self.assertIn(str(post.return_value.status_code), str(cm.exception))
+        try:
+            keen.add_event("python_test", {"hello": "goodbye"})
+        except exceptions.KeenApiError as e:
+
+            exception = e
+
+        self.assertIn(post.return_value.text, str(exception))
+        self.assertIn(str(post.return_value.status_code), str(exception))
 
     def test_environment_variables(self, post):
         post.return_value = MockedFailedResponse(

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -144,8 +144,8 @@ class ClientTests(BaseTestCase):
 
             exception = e
 
-        self.assertIn(post.return_value.text, str(exception))
-        self.assertIn(str(post.return_value.status_code), str(exception))
+        self.assertTrue(post.return_value.text in str(exception))
+        self.assertTrue(str(post.return_value.status_code) in str(exception))
 
     def test_environment_variables(self, post):
         post.return_value = MockedFailedResponse(

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -132,7 +132,7 @@ class ClientTests(BaseTestCase):
     def test_malformed_json_response(self, post):
         post.return_value = MockedMalformedJsonResponse(
             status_code=401,
-            json_response={},
+            json_response=" ",
             text="test error text"
         )
 

--- a/keen/tests/client_tests.py
+++ b/keen/tests/client_tests.py
@@ -15,9 +15,10 @@ __author__ = 'dkador'
 
 
 class MockedResponse(object):
-    def __init__(self, status_code, json_response):
+    def __init__(self, status_code, json_response, text=None):
         self.status_code = status_code
         self.json_response = json_response
+        self.text = text
 
     def json(self):
         return self.json_response
@@ -26,6 +27,11 @@ class MockedResponse(object):
 class MockedFailedResponse(MockedResponse):
     def json(self):
         return self.json_response
+
+
+class MockedMalformedJsonResponse(MockedResponse):
+    def json(self):
+        raise ValueError
 
 
 @patch("requests.Session.post")
@@ -122,6 +128,19 @@ class ClientTests(BaseTestCase):
     def test_post_timeout_batch(self, post):
         post.side_effect = requests.Timeout
         self.assert_raises(requests.Timeout, keen.add_events, {"python_test": [{"hello": "goodbye"}]})
+
+    def test_malformed_json_response(self, post):
+        post.return_value = MockedMalformedJsonResponse(
+            status_code=401,
+            json_response={},
+            text="test error text"
+        )
+
+        with self.assert_raises(exceptions.KeenApiError) as cm:
+            keen.add_event("python_test", {"hello": "goodbye"})
+
+        self.assertIn(post.return_value.text, str(cm.exception))
+        self.assertIn(str(post.return_value.status_code), str(cm.exception))
 
     def test_environment_variables(self, post):
         post.return_value = MockedFailedResponse(
@@ -296,6 +315,7 @@ class ClientTests(BaseTestCase):
         except AttributeError:
             import urllib.parse
             return urllib.parse.quote(url)
+
 
 class EventTests(BaseTestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if sys.version_info < (2, 7):
 
 setup(
     name="keen",
-    version="0.3.22",
+    version="0.3.23",
     description="Python Client for Keen IO",
     author="Keen IO",
     author_email="team@keen.io",


### PR DESCRIPTION
I've added the status code to the exception message returned when there are JSON parse errors.

We try to return response `res.json()`. When that fails, we return an error message body including `res.text` and now `res.status_code`. Server responses without message bodies (i.e. no `res.text`) should now have status codes.  

Hopefully this change will help troubleshoot #32 