### PR TITLE
Adding missing `VERSION` file to sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements.txt
 include README.md
 include LICENSE.txt
+include VERSION


### PR DESCRIPTION
This fixes following error when building from source distribution
```
Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/ch/72dmd7t14cq6nr3gp86qync40000gp/T/pip-build-jncV6o/keen/setup.py", line 29, in <module>
        version_file = open(os.path.join('.', 'VERSION'))
    IOError: [Errno 2] No such file or directory: './VERSION'
```