### PR TITLE
Accept dict in SavedQueriesInterface.create()

### DIFF
--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -1,3 +1,6 @@
+
+import json
+
 from keen.api import KeenApi
 from keen import exceptions, utilities
 
@@ -40,7 +43,7 @@ class SavedQueriesInterface:
 
     def results(self, query_name):
         """
-        Gets a single saved query with a 'result' object for a project from thei
+        Gets a single saved query with a 'result' object for a project from the
         Keen IO API given a query name.
         Read or Master key must be set.
         """
@@ -57,15 +60,18 @@ class SavedQueriesInterface:
 
     def create(self, query_name, saved_query):
         """
-        Creates the saved query via a PUT request to Keen IO Saved Query endpoint. Master key must be set.
+        Creates the saved query via a PUT request to Keen IO Saved Query endpoint.
+        Master key must be set.
         """
         keen_api = KeenApi(self.project_id, master_key=self.master_key)
         self._check_for_master_key()
         url = "{0}/{1}/projects/{2}/queries/saved/{3}".format(
             keen_api.base_url, keen_api.api_version, self.project_id, query_name
         )
+        
+        payload = json.dumps(saved_query)
         response = keen_api.fulfill(
-            "put", url, headers=utilities.headers(self.master_key), data=saved_query
+            "put", url, headers=utilities.headers(self.master_key), data=payload
         )
         keen_api._error_handling(response)
 

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -68,7 +68,7 @@ class SavedQueriesInterface:
         url = "{0}/{1}/projects/{2}/queries/saved/{3}".format(
             keen_api.base_url, keen_api.api_version, self.project_id, query_name
         )
-        
+
         payload = json.dumps(saved_query)
         response = keen_api.fulfill(
             "put", url, headers=utilities.headers(self.master_key), data=payload

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -69,7 +69,15 @@ class SavedQueriesInterface:
             keen_api.base_url, keen_api.api_version, self.project_id, query_name
         )
 
-        payload = json.dumps(saved_query)
+        payload = saved_query
+
+        # To support clients that may have already called dumps() to work around how this used to
+        # work, make sure it's not a str. Hopefully it's some sort of mapping. When we actually
+        # try to send the request, client code will get an InvalidJSONError if payload isn't
+        # a json-formatted string.
+        if not isinstance(payload, str):
+            payload = json.dumps(saved_query)
+
         response = keen_api.fulfill(
             "put", url, headers=utilities.headers(self.master_key), data=payload
         )


### PR DESCRIPTION
Accept a dict for the saved_query properties, and convert to a json-formatted str to send as the PUT payload. Fixes Issue #119 
- This is technically a breaking change since, if client code is using this and working around it by calling ```my_keen_client.saved_queries.create('new_query_name', json.dumps(new_query_attributes))```, then this will no longer work.
- This code has been in the repo for a long time, so I'm not sure how to handle this version-wise.