### PR TITLE
Saved Query partial update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 # command to install dependencies
 install: "pip install -r requirements.txt"
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,19 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.2"
   - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
 # command to install dependencies
-install: "pip install -r requirements.txt"
+install: |
+  if [ "$TRAVIS_PYTHON_VERSION" == 3.2 ]
+  then
+    pip install "setuptools<30"
+  fi
+
+  pip install -r requirements.txt
+
 # command to run tests
 script: "python setup.py test"

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Use pip to install!
 
     pip install keen
 
-This client is known to work on Python 2.6, 2.7, 3.2, 3.3, 3.4 and 3.5.
+This client is known to work on Python 2.6, 2.7, 3.2, 3.3, 3.4, 3.5 and 3.6.
 
 For versions of Python < 2.7.9, you’ll need to install pyasn1, ndg-httpsclient, pyOpenSSL.
 
@@ -283,6 +283,7 @@ You can manage your `saved queries <https://keen.io/docs/api/?shell#saved-querie
             }]
         }
     }
+
     client.saved_queries.create("saved-query-name", saved_query_attributes)
 
     # Get all saved queries
@@ -297,15 +298,31 @@ You can manage your `saved queries <https://keen.io/docs/api/?shell#saved-querie
     # NOTE : Updating Saved Queries requires sending the entire query definition. Any attribute not
     # sent is interpreted as being cleared/removed. This means that properties set via another
     # client, including the Projects Explorer Web UI, will be lost this way.
+    # 
+    # The update() function makes this easier by allowing client code to just specify the
+    # properties that need updating. To do this, it will retrieve the existing query definition
+    # first, which means there will be two HTTP requests. Use update_full() in code that already
+    # has a full query definition that can reasonably be expected to be current.
 
-    # Update a saved query to now be a cached query with the minimum refresh rate of 4 hrs
+    # Update a saved query to now be a cached query with the minimum refresh rate of 4 hrs...
+
+    # ...using partial update:
+    client.saved_queries.update("saved-query-name", { "refresh_rate": 14400 })
+
+    # ...using full update, if we've already fetched the query definition:
     saved_query_attributes["refresh_rate"] = 14400
-    client.saved_queries.update("saved-query-name", saved_query_attributes)
+    client.saved_queries.update_full("saved-query-name", saved_query_attributes)
 
-    # Update a saved query to a new resource name
-    # We send "refresh_rate" again, along with the entire definition, or else it would be reset.
+    # Update a saved query to a new resource name...
+
+    # ...using partial update:
+    client.saved_queries.update("saved-query-name", { "query_name": "cached-query-name" })
+
+    # ...using full update, if we've already fetched the query definition or have it lying around
+    # for whatever reason. We send "refresh_rate" again, along with the entire definition, or else
+    # it would be reset:
     saved_query_attributes["query_name"] = "cached-query-name"
-    client.saved_queries.update("saved-query-name", saved_query_attributes)
+    client.saved_queries.update_full("saved-query-name", saved_query_attributes)
 
     # Delete a saved query (use the new resource name since we just changed it)
     client.saved_queries.delete("cached-query-name")

--- a/README.rst
+++ b/README.rst
@@ -283,7 +283,7 @@ You can manage your `saved queries <https://keen.io/docs/api/?shell#saved-querie
             }]
         }
     }
-    client.saved_queries.create("name", saved_query_attributes)
+    client.saved_queries.create("saved-query-slug", saved_query_attributes)
 
     # Get all saved queries
     client.saved_queries.all()
@@ -294,12 +294,17 @@ You can manage your `saved queries <https://keen.io/docs/api/?shell#saved-querie
     # Get saved query with results
     client.saved_queries.results("saved-query-slug")
 
+    # NOTE : Updating Saved Queries requires sending the entire query definition. Any attribute not
+    # sent is interpreted as being cleared/removed. This means that properties set via another
+    # client, including the Projects Explorer Web UI, will be lost this way.
+
     # Update a saved query to now be a cached query with the minimum refresh rate of 4 hrs
-    saved_query_attributes = { "refresh_rate": 14400 }
+    saved_query_attributes["refresh_rate"] = 14400
     client.saved_queries.update("saved-query-slug", saved_query_attributes)
 
     # Update a saved query to a new resource name
-    saved_query_attributes = { "query_name": "cached-query-slug" }
+    # We send "refresh_rate" again, along with the entire definition, or else it would be reset.
+    saved_query_attributes["query_name"] = "cached-query-slug"
     client.saved_queries.update("saved-query-slug", saved_query_attributes)
 
     # Delete a saved query (use the new resource name since we just changed it)

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -1,11 +1,11 @@
 
-try:
-    from collections.abc import Mapping as Mapping  # for Python 3
-except ImportError as ie:
-    from collections import Mapping as Mapping  # for Python 2
-
 import json
 import six
+
+if six.PY3:
+    from collections.abc import Mapping
+elif six.PY2:
+    from collections import Mapping
 
 from keen.api import KeenApi, HTTPMethods
 from keen import exceptions, utilities
@@ -128,7 +128,6 @@ class SavedQueriesInterface:
         # for 'group_by', 'interval' or 'timezone', but those aren't accepted values when updating.
         old_query = old_saved_query[query_attr_name] # expected
 
-        # Using dict.items() in both Python 2.x and Python 3.x. iteritems() might be better in 2.7.
         # Shallow copy since we want the entire object heirarchy to start with.
         for (key, value) in six.iteritems(old_query):
             if value:

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -2,9 +2,9 @@
 import json
 import six
 
-if six.PY3:
-    from collections.abc import Mapping
-elif six.PY2:
+try:
+    from collections.abc import Mapping # Python >=3.3
+except ImportError:
     from collections import Mapping
 
 from keen.api import KeenApi, HTTPMethods

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -7,8 +7,8 @@ try:
 except ImportError:
     from collections import Mapping
 
-from keen.api import KeenApi, HTTPMethods
-from keen import exceptions, utilities
+from keen.api import HTTPMethods
+from keen import utilities
 from keen.utilities import KeenKeys, requires_key
 
 
@@ -146,7 +146,7 @@ class SavedQueriesInterface:
         """
 
         url = "{0}/{1}".format(self.saved_query_url, query_name)
-        response = self._get_json(HTTPMethods.DELETE, url, self._get_master_key())
+        self._get_json(HTTPMethods.DELETE, url, self._get_master_key())
 
         return True
 

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -65,14 +65,65 @@ class SavedQueriesInterface:
         return response
 
     @requires_key(KeenKeys.MASTER)
-    def update(self, query_name, saved_query):
+    def update(self, query_name, saved_query_full_definition):
         """
         Updates the saved query via a PUT request to Keen IO Saved Query
-        endpoint.
+        endpoint. The entire query definition must be provided--anything
+        excluded will be considered an explicit removal of that property.
         Master key must be set.
         """
 
-        return self.create(query_name, saved_query)
+        return self.create(query_name, saved_query_full_definition)
+
+    @requires_key(KeenKeys.MASTER)
+    def update_partial(self, query_name, saved_query_attributes):
+        """
+        Given a dict of attributes to be updated, update only those attributes
+        in the Saved Query at the resource given by 'query_name'. This will
+        perform two HTTP requests--one to fetch the query definition, and one
+        to set the new attributes. This method will intend to preserve any
+        other properties on the query.
+
+        Master key must be set.
+        """
+
+        query_name_attr_name = "query_name"
+        refresh_rate_attr_name = "refresh_rate"
+        query_attr_name = "query"
+        metadata_attr_name = "metadata"
+
+        old_saved_query = self.get(query_name)
+
+        # Create a new query def to send back. We cannot send values for attributes like 'urls',
+        # 'last_modified_date', 'run_information', etc.
+        new_saved_query = {
+            query_name_attr_name: old_saved_query[query_name_attr_name], # expected
+            refresh_rate_attr_name: old_saved_query[refresh_rate_attr_name], # expected
+            query_attr_name: {}
+        }
+
+        # If metadata was set, preserve it. The Explorer UI currently stores information here.
+        old_metadata = (old_saved_query[metadata_attr_name]
+                       if hasattr(old_saved_query, metadata_attr_name)
+                       else None)
+
+        if old_metadata:
+            new_saved_query[metadata_attr_name] = old_metadata
+
+        # Preserve any non-empty properties of the existing query. We get back values like None
+        # for 'group_by', 'interval' or 'timezone', but those aren't accepted values when updating.
+        old_query = old_saved_query[query_attr_name] # expected
+
+        # Using dict.items() in both Python 2.x and Python 3.x. iteritems() might be better in 2.7.
+        # Shallow copy since we want the entire object heirarchy to start with.
+        for (key, value) in old_query.items():
+            if value:
+                new_saved_query[query_attr_name][key] = value
+
+        # Now, recursively overwrite any attributes passed in.
+        _deep_update(new_saved_query, saved_query_attributes)
+
+        return self.create(query_name, new_saved_query)
 
     @requires_key(KeenKeys.MASTER)
     def delete(self, query_name):
@@ -86,8 +137,30 @@ class SavedQueriesInterface:
 
         return True
 
+    def _deep_update(mapping, updates):
+        # NOTE : Careful with items()/iteritems()/viewitems() on Python 2 vs 3.
+        for (key, value) in updates.items():
+            # NOTE : should really check collections/collections.abc Mapping instead of dict.
+            if isinstance(mapping, dict):
+                if isinstance(value, dict):
+                    next_level_value = _deep_update(mapping.get(key, {}), value)
+                    mapping[key] = next_level_value
+                else:
+                    mapping[key] = value
+            else:
+                # Turn the original key into a mapping if it wasn't already
+                mapping = { key: value }
+
+        return mapping
+
     def _get_json(self, http_method, url, key, *args, **kwargs):
-        response = self.api.fulfill(http_method, url, headers=utilities.headers(key), *args, **kwargs)
+        response = self.api.fulfill(
+            http_method,
+            url,
+            headers=utilities.headers(key),
+            *args,
+            **kwargs)
+
         self.api._error_handling(response)
 
         try:

--- a/keen/scoped_keys.py
+++ b/keen/scoped_keys.py
@@ -15,9 +15,9 @@ DEFAULT_ENCODING = 'UTF-8'
 
 
 def ensure_bytes(s, encoding=None):
-	if isinstance(s, six.text_type):
-		return s.encode(encoding or DEFAULT_ENCODING)
-	return s
+    if isinstance(s, six.text_type):
+        return s.encode(encoding or DEFAULT_ENCODING)
+    return s
 
 
 def pad_aes256(s):

--- a/keen/tests/base_test_case.py
+++ b/keen/tests/base_test_case.py
@@ -1,5 +1,5 @@
 import string
-import unittest
+import unittest2 as unittest
 
 __author__ = 'dkador'
 

--- a/keen/tests/saved_query_tests.py
+++ b/keen/tests/saved_query_tests.py
@@ -1,4 +1,3 @@
-import copy
 import json
 import re
 from requests.exceptions import HTTPError
@@ -124,7 +123,7 @@ class SavedQueryTests(BaseTestCase):
             responses.GET, url, status=200, json=original_query
         )
 
-        updated_query = { "query": {} } # copy.deepcopy(original_query)
+        updated_query = { "query": {} }
         new_analysis_type = "sum"
         updated_query["query"]["analysis_type"] = new_analysis_type
 

--- a/keen/tests/saved_query_tests.py
+++ b/keen/tests/saved_query_tests.py
@@ -1,8 +1,13 @@
+import copy
+import json
+import re
+from requests.exceptions import HTTPError
+import responses
+
 from keen.tests.base_test_case import BaseTestCase
 from keen.client import KeenClient
 from keen import exceptions
 
-import responses
 
 class SavedQueryTests(BaseTestCase):
 
@@ -93,6 +98,67 @@ class SavedQueryTests(BaseTestCase):
 
     @responses.activate
     def test_update_saved_query(self):
+        unacceptable_attr = "run_information"
+        metadata_attr_name = "metadata"
+
+        original_query = {
+            "query_name": "saved-query-name",
+            "refresh_rate": 14400,
+            "query": {
+                "analysis_type": "average",
+                "event_collection": "TheCollection",
+                "target_property": "TheProperty",
+                "timeframe": "this_2_weeks"
+            },
+            metadata_attr_name: { "foo": "bar" },
+            unacceptable_attr: { "foo": "bar" }
+        }
+
+        url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.exp_project_id
+        )
+
+        responses.add(
+            responses.GET, url, status=200, json=original_query
+        )
+
+        updated_query = { "query": {} } # copy.deepcopy(original_query)
+        new_analysis_type = "sum"
+        updated_query["query"]["analysis_type"] = new_analysis_type
+
+        def request_callback(request):
+            payload = json.loads(request.body)
+
+            # Ensure update() round-trips some necessary things like "metadata"
+            self.assertEqual(payload[metadata_attr_name], original_query[metadata_attr_name])
+
+            # Ensure update() doesn't pass unacceptable attributes
+            self.assertNotIn(unacceptable_attr, payload)
+
+            # Ensure update() merges deep updates
+            self.assertEqual(payload["query"]["analysis_type"], new_analysis_type)
+            payload["query"]["analysis_type"] = "average"
+            payload[unacceptable_attr] = original_query[unacceptable_attr]
+            self.assertEqual(payload, original_query)
+
+            headers = {}
+            return (200, headers, json.dumps(updated_query))
+
+        responses.add_callback(
+            responses.PUT,
+            url,
+            callback=request_callback,
+            content_type='application/json',
+        )
+
+        saved_query = self.client.saved_queries.update("saved-query-name", updated_query)
+
+        self.assertEqual(saved_query, updated_query)
+
+    @responses.activate
+    def test_update_full_saved_query(self):
         saved_queries_response = {
             "query_name": "saved-query-name",
             "refresh_rate": 14400,
@@ -101,25 +167,37 @@ class SavedQueryTests(BaseTestCase):
                 "event_collection": "TheCollection",
                 "target_property": "TheProperty",
                 "timeframe": "this_2_weeks"
-                }
+            }
         }
+
         url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
             self.client.api.base_url,
             self.client.api.api_version,
             self.exp_project_id
         )
 
-        responses.add(
-            responses.GET, url, status=200, json=saved_queries_response
+        # Unlike update(), update_full() should not be fetching the existing definition.
+        exception = HTTPError("No GET expected when performing a full update.")
+        responses.add(responses.GET, re.compile(".*"), body=exception)
+
+        def request_callback(request):
+            payload = json.loads(request.body)
+
+            # Ensure update_full() passes along the unaltered complete Saved/Cached Query def.
+            self.assertEqual(payload, saved_queries_response)
+            headers = {}
+            return (200, headers, json.dumps(saved_queries_response))
+
+        responses.add_callback(
+            responses.PUT,
+            url,
+            callback=request_callback,
+            content_type='application/json',
         )
 
-        responses.add(
-            responses.PUT, url, status=200, json=saved_queries_response
-        )
+        saved_query = self.client.saved_queries.update_full("saved-query-name", saved_queries_response)
 
-        saved_query = self.client.saved_queries.update("saved-query-name", saved_queries_response)
-
-        self.assertEquals(saved_query, saved_queries_response)
+        self.assertEqual(saved_query, saved_queries_response)
 
     def test_delete_saved_query_master_key(self):
         client = KeenClient(project_id="123123", read_key="123123")

--- a/keen/tests/saved_query_tests.py
+++ b/keen/tests/saved_query_tests.py
@@ -89,18 +89,30 @@ class SavedQueryTests(BaseTestCase):
 
         saved_query = self.client.saved_queries.create("saved-query-name", saved_queries_response)
 
-        self.assertEquals(saved_query, saved_queries_response)
+        self.assertEqual(saved_query, saved_queries_response)
 
     @responses.activate
     def test_update_saved_query(self):
         saved_queries_response = {
-            "query_name": "saved-query-name"
+            "query_name": "saved-query-name",
+            "refresh_rate": 14400,
+            "query": {
+                "analysis_type": "average",
+                "event_collection": "TheCollection",
+                "target_property": "TheProperty",
+                "timeframe": "this_2_weeks"
+                }
         }
         url = "{0}/{1}/projects/{2}/queries/saved/saved-query-name".format(
             self.client.api.base_url,
             self.client.api.api_version,
             self.exp_project_id
         )
+
+        responses.add(
+            responses.GET, url, status=200, json=saved_queries_response
+        )
+
         responses.add(
             responses.PUT, url, status=200, json=saved_queries_response
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pycryptodome>=3.4
 requests>=2.5,<2.11.0
+six~=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,7 @@ reqs_file = open(os.path.join(setup_path, 'requirements.txt'), 'r')
 reqs = reqs_file.readlines()
 reqs_file.close()
 
-tests_require = ['nose', 'mock', 'responses']
-
-if sys.version_info < (2, 7):
-    tests_require.append('unittest2')
+tests_require = ['nose', 'mock', 'responses', 'unittest2']
 
 setup(
     name="keen",


### PR DESCRIPTION
This change hasn't been properly tested and would need to be cleaned up before getting merged. The purpose is to show what would need to happen to enable partial updates to a Saved/Cached Query while trying to preserve remote changes (e.g. - changes made via the Project Explorer Web UI), and to discuss that a little bit.
- A README.rst change will probably need to happen either way, but if the follow-up change is accepted in a cleaned-up/tested manner, we can augment the readme to add a sample of the behavior we settle on.