### PR TITLE
rm pycryptodome

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -544,12 +544,15 @@ Create Scoped Keys (**Deprecated**)
 ''''''''''''''''''
 
 The Python client enables you to create `Scoped Keys <https://keen.io/docs/security/#scoped-key>`_ easily, but Access Keys are better! 
-If you need to use them anyway, for legacy reasons, here's how:
+If you need to use them anyway, here's how:
+
+.. code-block:: bash
+    pip install pycryptodome
 
 .. code-block:: python
 
     from keen.client import KeenClient
-    from keen import scoped_keys
+    from keen import scoped_keys # You must have pycryptodome installed!
 
     api_key = KEEN_MASTER_KEY
 

--- a/keen/scoped_keys.py
+++ b/keen/scoped_keys.py
@@ -2,8 +2,15 @@ import binascii
 import json
 import os
 import six
-from Crypto.Cipher import AES
 
+try:
+    from Crypto.Cipher import AES
+except ImportError as ie:
+    ie.args = (ie.args[0] + ' -- Scoped Keys are deprecated in favor'
+               ' of Access Keys. To use Scoped Keys anyway, run: '
+               '`pip install pycryptodome` and try this again.',)
+    raise ie
+ 
 from keen import Padding
 
 __author__ = 'dkador'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-pycryptodome>=3.4
 requests>=2.5,<3.0
 six~=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ reqs_file = open(os.path.join(setup_path, 'requirements.txt'), 'r')
 reqs = reqs_file.readlines()
 reqs_file.close()
 
-tests_require = ['nose', 'mock', 'responses==0.5.1', 'unittest2']
+tests_require = ['nose', 'mock', 'responses==0.5.1', 'unittest2', 'pycryptodome>=3.4']
 
 setup(
     name="keen",


### PR DESCRIPTION
Scoped Keys are deprecated and pycryptodome is not pure python
making it a problem for people wanting to `pip install keen` on
some systems. pycryptodome is a dependency of only scoped keys.

To make the tests pass, you'll need to have it installed but that
is enabled via the test_requires within setup.py. A fun error
message is displayed when anything scoped keys are imported. This
may make `from keen import *` fail, but that's bad python to begin
with so I don't feel very bad about that.

This includes a documentation update reflecting the manual step
required for the deprecated feature.

## Testing

Try running the test suite without pycryptodome installed. It should still succeed.
Try `import keen.scoped_keys` without pycryptodome installed. It should fail with a message.

## Related tickets

#131 