### PR TITLE
Access keys fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 ---------
 
+0.5.1
+``````
+
++ Fixed various Access Key bugs.
+
 0.5.0
 ``````
 + Added support for Access Keys.

--- a/README.rst
+++ b/README.rst
@@ -572,7 +572,7 @@ To run tests:
 Changelog
 ---------
 
-This project is in alpha stage at version 0.5.0 . See the full CHANGELOG `here <./CHANGELOG.rst>`_.
+This project is in alpha stage at version 0.5.1 . See the full CHANGELOG `here <./CHANGELOG.rst>`_.
 
 
 Questions & Support

--- a/keen/__init__.py
+++ b/keen/__init__.py
@@ -576,7 +576,7 @@ def update_access_key_permissions(access_key_id, permissions):
     _initialize_client_from_environment()
     return _client.update_access_key_permissions(access_key_id, permissions)
 
-def update_access_key_options(self, access_key_id, options):
+def update_access_key_options(access_key_id, options):
     """
     Replaces all of the options on the access key but does not change
     non-option properties such as permissions or the key's name.

--- a/keen/api.py
+++ b/keen/api.py
@@ -333,7 +333,7 @@ class KeenApi(object):
         current_access_key = self.get_access_key(access_key_id)
 
         # Copy and only change the single parameter.
-        payload_dict = _build_access_key_dict(current_access_key)
+        payload_dict = KeenApi._build_access_key_dict(current_access_key)
         payload_dict[key] = val
 
         # Now just treat it like a full update.
@@ -362,13 +362,13 @@ class KeenApi(object):
         current_access_key = self.get_access_key(access_key_id)
 
         # Copy and only change the single parameter.
-        payload_dict = _build_access_key_dict(current_access_key)
+        payload_dict = KeenApi._build_access_key_dict(current_access_key)
 
         # Turn into sets to avoid duplicates.
-        old_permissions = set(payload_dict["permissions"])
+        old_permissions = set(payload_dict["permitted"])
         new_permissions = set(permissions)
         combined_permissions = old_permissions.union(new_permissions)
-        payload_dict["permissions"] = list(combined_permissions)
+        payload_dict["permitted"] = list(combined_permissions)
 
         # Now just treat it like a full update.
         return self.update_access_key_full(access_key_id, **payload_dict)
@@ -389,13 +389,13 @@ class KeenApi(object):
         current_access_key = self.get_access_key(access_key_id)
 
         # Copy and only change the single parameter.
-        payload_dict = _build_access_key_dict(current_access_key)
+        payload_dict = KeenApi._build_access_key_dict(current_access_key)
 
         # Turn into sets to avoid duplicates.
-        old_permissions = set(payload_dict["permissions"])
+        old_permissions = set(payload_dict["permitted"])
         removal_permissions = set(permissions)
-        reduced_permissions = old_permissions.difference_update(removal_permissions)
-        payload_dict["permissions"] = list(reduced_permissions)
+        reduced_permissions = old_permissions.difference(removal_permissions)
+        payload_dict["permitted"] = list(reduced_permissions)
 
         # Now just treat it like a full update.
         return self.update_access_key_full(access_key_id, **payload_dict)
@@ -411,7 +411,7 @@ class KeenApi(object):
         :param access_key_id: the 'key' value of the access key to change the permissions of
         :param permissions: the new list of permissions for this key
         """
-        return self._update_access_key_pair(access_key_id, "permissions", permission)
+        return self._update_access_key_pair(access_key_id, "permitted", permissions)
 
     @requires_key(KeenKeys.MASTER)
     def update_access_key_options(self, access_key_id, options):

--- a/keen/utilities.py
+++ b/keen/utilities.py
@@ -5,7 +5,7 @@ from functools import wraps
 from keen import exceptions
 
 
-VERSION = "0.5.0"
+VERSION = "0.5.1"
 
 def version():
     """

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = ['nose', 'mock', 'responses==0.5.1', 'unittest2']
 
 setup(
     name="keen",
-    version="0.5.0",
+    version="0.5.1",
     description="Python Client for Keen IO",
     long_description=codecs.open(os.path.join('README.rst'), 'r', encoding='UTF-8').read(),
     author="Keen IO",


### PR DESCRIPTION
Nonexisting unit tests... are a bad idea.
Sanity testing showed several of the access key
functions were horribly broken.

Also the tests were slightly misleading in their mocking
of the ACCESS_KEY_ID. Namely, the user-supplied NAME was
being used where in practice it would not actually work.

