### PR TITLE
Cached Datasets Support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -406,6 +406,85 @@ You can manage your `saved queries <https://keen.io/docs/api/?shell#saved-querie
     # Delete a saved query (use the new resource name since we just changed it)
     client.saved_queries.delete("cached-query-name")
 
+Cached Datasets
+'''''''''''''''
+.. code-block:: python
+
+    # Create your KeenClient
+    from keen.client import KeenClient
+
+    client = KeenClient(
+        project_id="xxxx",  # your project ID
+        read_key="zzzz",
+        master_key="abcd" 
+    )
+
+    # Create a Cached Dataset
+    dataset_name = "NEW_DATASET"
+    display_name = "My new dataset"
+    query = {
+        "project_id": "PROJECT ID",
+        "analysis_type": "count",
+        "event_collection": "purchases",
+        "filters": [
+            {
+                "property_name": "price",
+                "operator": "gte",
+                "property_value": 100
+            }
+        ],
+        "timeframe": "this_500_days",
+        "timezone": None,
+        "interval": "daily",
+        "group_by": ["ip_geo_info.country"]
+    }
+    index_by = "product.id"
+    client.cached_datasets.create(
+        dataset_name,
+        query,
+        index_by,
+        display_name
+    )
+
+    # Get all Cached Datasets
+    client.cached_datasets.all()
+
+    # Get one Cached Dataset
+    client.cached_datasets.get(dataset_name)
+
+    # Retrieve Cached Dataset results
+    index_by = "a_project_id"
+    timeframe ="this_2_hours"
+    client.cached_datasets.results(
+        dataset_name,
+        index_by,
+        timeframe
+    )
+
+    # Using an absolute timeframe
+    timeframe = {
+        "start": "2018-11-02T00:00:00.000Z",
+        "end": "2018-11-02T02:00:00.000Z"
+    }
+    client.cached_datasets.results(
+        dataset_name,
+        index_by,
+        timeframe
+    )
+
+    # Using multiple index_by values
+    index_by = {
+        "project.id": "a_project_id",
+        "project.foo": "bar"
+    }
+    client.cached_datasets.results(
+        "dataset_with_multiple_indexes",
+        index_by,
+        timeframe
+    )
+
+    # Delete a Cached Dataset
+    client.cached_datasets.delete(dataset_name)
 
 Overwriting event timestamps
 ''''''''''''''''''''''''''''

--- a/keen/cached_datasets.py
+++ b/keen/cached_datasets.py
@@ -29,6 +29,18 @@ class CachedDatasetsInterface:
         url = "{}/{}".format(self._cached_datasets_url, dataset_name)
         return self._get_json(HTTPMethods.GET, url, self._get_read_key())
 
+    @requires_key(KeenKeys.MASTER)
+    def create(self, dataset_name, query, index_by, display_name):
+        """ Create a Cached Dataset for a Project. Master key must be set.
+        """
+        url = "{}/{}".format(self._cached_datasets_url, dataset_name)
+        payload = {
+            "query": query,
+            "index_by": index_by,
+            "display_name": display_name
+        }
+        return self._get_json(HTTPMethods.PUT, url, self._get_master_key(), json=payload)
+
     def _get_json(self, http_method, url, key, *args, **kwargs):
         response = self.api.fulfill(
             http_method,

--- a/keen/cached_datasets.py
+++ b/keen/cached_datasets.py
@@ -1,0 +1,44 @@
+import json
+
+from keen.api import HTTPMethods
+from keen.utilities import KeenKeys, headers, requires_key
+
+
+class CachedDatasetsInterface:
+
+    def __init__(self, api):
+        self.api = api
+        self._cached_datasets_url = "{0}/{1}/projects/{2}/datasets".format(
+            self.api.base_url, self.api.api_version, self.api.project_id
+        )
+
+    @requires_key(KeenKeys.READ)
+    def all(self):
+        """ Fetch all Cached Datasets for a Project. Read key must be set.
+        """
+        return self._get_json(HTTPMethods.GET,
+                              self._cached_datasets_url,
+                              self._get_master_key())
+
+    def _get_json(self, http_method, url, key, *args, **kwargs):
+        response = self.api.fulfill(
+            http_method,
+            url,
+            headers=headers(key),
+            *args,
+            **kwargs)
+
+        self.api._error_handling(response)
+
+        try:
+            response = response.json()
+        except ValueError:
+            response = "No JSON available."
+
+        return response
+
+    def _get_read_key(self):
+        return self.api._get_read_key()
+
+    def _get_master_key(self):
+        return self.api._get_master_key()

--- a/keen/cached_datasets.py
+++ b/keen/cached_datasets.py
@@ -20,6 +20,15 @@ class CachedDatasetsInterface:
                               self._cached_datasets_url,
                               self._get_master_key())
 
+    @requires_key(KeenKeys.READ)
+    def get(self, dataset_name):
+        """ Fetch a single Cached Dataset for a Project. Read key must be set.
+
+        :param dataset_name: Name of Cached Dataset (not `display_name`)
+        """
+        url = "{}/{}".format(self._cached_datasets_url, dataset_name)
+        return self._get_json(HTTPMethods.GET, url, self._get_read_key())
+
     def _get_json(self, http_method, url, key, *args, **kwargs):
         response = self.api.fulfill(
             http_method,

--- a/keen/cached_datasets.py
+++ b/keen/cached_datasets.py
@@ -41,6 +41,24 @@ class CachedDatasetsInterface:
         }
         return self._get_json(HTTPMethods.PUT, url, self._get_master_key(), json=payload)
 
+    @requires_key(KeenKeys.READ)
+    def results(self, dataset_name, index_by, timeframe):
+        """ Retrieve results from a Cached Dataset. Read key must be set.
+        """
+        url = "{0}/{1}/results".format(self._cached_datasets_url, dataset_name)
+
+        index_by = index_by if isinstance(index_by, str) else json.dumps(index_by)
+        timeframe = timeframe if isinstance(timeframe, str) else json.dumps(timeframe)
+
+        query_params = {
+            "index_by": index_by,
+            "timeframe": timeframe
+        }
+
+        return self._get_json(
+            HTTPMethods.GET, url, self._get_read_key(), params=query_params
+        )
+
     def _get_json(self, http_method, url, key, *args, **kwargs):
         response = self.api.fulfill(
             http_method,

--- a/keen/cached_datasets.py
+++ b/keen/cached_datasets.py
@@ -26,14 +26,14 @@ class CachedDatasetsInterface:
 
         :param dataset_name: Name of Cached Dataset (not `display_name`)
         """
-        url = "{}/{}".format(self._cached_datasets_url, dataset_name)
+        url = "{0}/{1}".format(self._cached_datasets_url, dataset_name)
         return self._get_json(HTTPMethods.GET, url, self._get_read_key())
 
     @requires_key(KeenKeys.MASTER)
     def create(self, dataset_name, query, index_by, display_name):
         """ Create a Cached Dataset for a Project. Master key must be set.
         """
-        url = "{}/{}".format(self._cached_datasets_url, dataset_name)
+        url = "{0}/{1}".format(self._cached_datasets_url, dataset_name)
         payload = {
             "query": query,
             "index_by": index_by,

--- a/keen/cached_datasets.py
+++ b/keen/cached_datasets.py
@@ -59,6 +59,14 @@ class CachedDatasetsInterface:
             HTTPMethods.GET, url, self._get_read_key(), params=query_params
         )
 
+    @requires_key(KeenKeys.MASTER)
+    def delete(self, dataset_name):
+        """ Delete a Cached Dataset. Master Key must be set.
+        """
+        url = "{0}/{1}".format(self._cached_datasets_url, dataset_name)
+        self._get_json(HTTPMethods.DELETE, url, self._get_master_key())
+        return True
+
     def _get_json(self, http_method, url, key, *args, **kwargs):
         response = self.api.fulfill(
             http_method,

--- a/keen/client.py
+++ b/keen/client.py
@@ -2,7 +2,7 @@ import base64
 import copy
 import json
 import sys
-from keen import persistence_strategies, exceptions, saved_queries
+from keen import persistence_strategies, exceptions, saved_queries, cached_datasets
 from keen.api import KeenApi
 from keen.persistence_strategies import BasePersistenceStrategy
 
@@ -98,6 +98,7 @@ class KeenClient(object):
         self.get_timeout = get_timeout
         self.post_timeout = post_timeout
         self.saved_queries = saved_queries.SavedQueriesInterface(self.api)
+        self.cached_datasets = cached_datasets.CachedDatasetsInterface(self.api)
 
     if sys.version_info[0] < 3:
         @staticmethod

--- a/keen/tests/cached_datasets_tests.py
+++ b/keen/tests/cached_datasets_tests.py
@@ -390,3 +390,24 @@ class CachedDatasetsTestCase(BaseTestCase):
         )
 
         self.assertEqual(results, keen_response)
+
+    def test_delete_raises_with_no_keys(self):
+        client = KeenClient(project_id=self.project_id)
+        with self.assertRaises(exceptions.InvalidEnvironmentError):
+            client.cached_datasets.delete("MY_DATASET_NAME")
+
+    def test_create_raises_with_read_key(self):
+        client = KeenClient(project_id=self.project_id, read_key=self.read_key)
+        with self.assertRaises(exceptions.InvalidEnvironmentError):
+            client.cached_datasets.delete("MY_DATASET_NAME")
+
+    @responses.activate
+    def test_delete(self):
+        dataset_name = "MY_DATASET_NAME"
+        url = "{0}/{1}/projects/{2}/datasets/{3}".format(
+            self.client.api.base_url, self.client.api.api_version, self.project_id, dataset_name)
+        responses.add(responses.DELETE, url, status=204)
+
+        response = self.client.cached_datasets.delete(dataset_name)
+
+        self.assertTrue(response)

--- a/keen/tests/cached_datasets_tests.py
+++ b/keen/tests/cached_datasets_tests.py
@@ -97,3 +97,20 @@ class CachedDatasetsTestCase(BaseTestCase):
         all_cached_datasets = self.client.cached_datasets.all()
 
         self.assertEquals(all_cached_datasets, keen_response)
+
+    def test_get_one_raises_with_no_keys(self):
+        client = KeenClient(project_id=self.project_id)
+
+        with self.assertRaises(exceptions.InvalidEnvironmentError):
+            client.cached_datasets.get()
+
+    @responses.activate
+    def test_get_one(self):
+        keen_response = self.datasets[0]
+
+        url = "{0}/{1}/projects/{2}/datasets/{3}".format(
+            self.client.api.base_url,
+            self.client.api.api_version,
+            self.project_id,
+            self.datasets[0]['dataset_name']
+        )

--- a/keen/tests/cached_datasets_tests.py
+++ b/keen/tests/cached_datasets_tests.py
@@ -1,0 +1,69 @@
+import responses
+
+from keen import exceptions
+from keen.client import KeenClient
+from keen.tests.base_test_case import BaseTestCase
+
+
+class CachedDatasetsTestCase(BaseTestCase):
+
+    def setUp(self):
+        super(CachedDatasetsTestCase, self).setUp()
+        self.organization_id = "1234xxxx5678"
+        self.project_id = "xxxx1234"
+        self.read_key = "abcd5678read"
+        self.master_key = "abcd5678master"
+        self.client = KeenClient(
+            project_id=self.project_id,
+            read_key=self.read_key,
+            master_key=self.master_key
+        )
+
+        self.datasets = [
+            {
+                "project_id": self.project_id,
+                "organization_id": self.organization_id,
+                "dataset_name": "DATASET_NAME_1",
+                "display_name": "a first dataset wee",
+                "query": {
+                    "project_id": self.project_id,
+                    "analysis_type": "count",
+                    "event_collection": "best collection",
+                    "filters": [
+                                {
+                                    "property_name": "request.foo",
+                                    "operator": "lt",
+                                    "property_value": 300,
+                                }
+                    ],
+                    "timeframe": "this_500_hours",
+                    "timezone": "US/Pacific",
+                    "interval": "hourly",
+                    "group_by": ["exception.name"],
+                },
+                "index_by": ["project.id"],
+                "last_scheduled_date": "2016-11-04T18:03:38.430Z",
+                "latest_subtimeframe_available": "2016-11-04T19:00:00.000Z",
+                "milliseconds_behind": 3600000,
+            },
+            {
+                "project_id": self.project_id,
+                "organization_id": self.organization_id,
+                "dataset_name": "DATASET_NAME_10",
+                "display_name": "tenth dataset wee",
+                "query": {
+                    "project_id": self.project_id,
+                    "analysis_type": "count",
+                    "event_collection": "tenth best collection",
+                    "filters": [],
+                    "timeframe": "this_500_days",
+                    "timezone": "UTC",
+                    "interval": "daily",
+                    "group_by": ["analysis_type"],
+                },
+                "index_by": ["project.organization.id"],
+                "last_scheduled_date": "2016-11-04T19:28:36.639Z",
+                "latest_subtimeframe_available": "2016-11-05T00:00:00.000Z",
+                "milliseconds_behind": 3600000,
+            },
+        ]


### PR DESCRIPTION
## What does this PR do? How does it affect users?
Adds [Cached Datasets](https://keen.io/docs/compute/cached-datasets/) support to `KeenClient`. This allows users to create, read, delete and retrieve results from Cached Datasets.

## How should this be tested?
Run unit tests

Try out the API live against a Keen Project (detailed examples in `README`)
- Create a Cached Dataset - `client.cached_datasets.create`
- Get a Cached Dataset - `client.cached_datasets.get`
- Get all Cached Datasets - `client.cached_datasets.create.all`
- Delete a Cached Dataset - `client.cached_datasets.delete`
- Retrieve results from a Cached Dataset - `client.cached_datasets.results`

Step through the code line by line. Things to keep in mind as you review:
 - Are there any edge cases not covered by this code?
 - Does this code follow conventions (naming, formatting, modularization, etc) where applicable?

Fetch the branch and/or deploy to staging to test the following:

- [ ] Does the code compile without warnings (check shell, console)?
- [ ] Do all tests pass?
- [ ] If the feature sends data to Keen, is the data visible in the project if you run an extraction (include link to collection/query)?
- [ ] If the feature saves data to a database, can you confirm the data is indeed created in the database?

## Related tickets?
#108 