### PR TITLE
Fix only six's major version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pycryptodome>=3.4
 requests>=2.5,<3.0
-six~=1.10
+six>=1.10,<2.0


### PR DESCRIPTION
This PR change the six dependency to fix only the major (1.X.Y) version. Libraries should not fix minor versions, it is a source of conflicts. If dependencies follow semver (which they should), upgrading a minor version should not break.