### PR TITLE
Configure automatic PyPI deployment when a branch is merged to master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,10 @@ install: |
 
 # command to run tests
 script: "python setup.py test"
+
+# deploy master to PyPI
+deploy:
+  provider: pypi
+  user: wiktor.olko
+  password:
+    secure: nxwi3BYKikV+nz3+OLWv7BXakLM2I+EafvCRiBoYUNQ2BBzg2pyBqwKna/AeqID8ASaHYWfHha64+7rDvJD1Sh7/Xgcc0GzDhtqUAiKXyKsdlg+4Q0XHWT3jeRTA2+vkqYMuren3MlbcSgzyyNO/IKf3zItiX+cA8/dyxRqOe3g=


### PR DESCRIPTION
I've added automatic deployment to PyPI when a branch is merged to master.

My goal was to use: PyPI-accessToken, however, I failed because of this issue:
https://travis-ci.community/t/travis-encrypt-data-too-large-for-pypi-tokens-with-older-repos/5792/6

As of now my credentials will be used (password generated by LastPass, encoded with the Travis projects publicKey). When the issue is resolved we will move to using accessTokens. 