### PR TITLE
Fix README.rst to comply with the ReStructuredText standard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -621,7 +621,7 @@ The Python client enables the creation and manipulation of `Access Keys <https:/
 
 
 Create Scoped Keys (**Deprecated**)
-''''''''''''''''''
+'''''''''''''''''''''''''''''''''''
 
 The Python client enables you to create `Scoped Keys <https://keen.io/docs/security/#scoped-key>`_ easily, but Access Keys are better! 
 If you need to use them anyway, for legacy reasons, here's how:
@@ -652,7 +652,7 @@ To run tests:
 Changelog
 ---------
 
-This project is in alpha stage at version 0.5.2. See the full CHANGELOG `here <./CHANGELOG.rst>`_.
+This project is in alpha stage at version 0.5.2. See the full `CHANGELOG <./CHANGELOG.rst>`_.
 
 
 Questions & Support


### PR DESCRIPTION
There were two issues:
1) line 624: Warning: Title underline too short. -> underline made longer
2) line 2: Warning: Duplicate explicit target name: "here" -> one occurrence replaced with CHANGELOG