### PR TITLE
Do not force TLSv1 which is deprecated

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 ---------
 
+0.7.0
+``````
+
++ Do not force TLSv1 which is deprecated
+
+
 0.6.1
 ``````
 

--- a/README.rst
+++ b/README.rst
@@ -655,7 +655,7 @@ To run tests:
 Changelog
 ---------
 
-This project is in alpha stage at version 0.6.1. See the full `CHANGELOG <./CHANGELOG.rst>`_.
+This project is in alpha stage at version 0.7.0. See the full `CHANGELOG <./CHANGELOG.rst>`_.
 
 
 Questions & Support

--- a/keen/api.py
+++ b/keen/api.py
@@ -34,12 +34,11 @@ class KeenAdapter(HTTPAdapter):
 
     def init_poolmanager(self, connections, maxsize, block=False):
 
-        """ Initialize pool manager with forced TLSv1 support. """
+        """ Initialize pool manager """
 
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
-                                       block=block,
-                                       ssl_version=ssl.PROTOCOL_TLSv1)
+                                       block=block)
 
 
 class KeenApi(object):

--- a/keen/utilities.py
+++ b/keen/utilities.py
@@ -5,7 +5,7 @@ from functools import wraps
 from keen import exceptions
 
 
-VERSION = "0.6.1"
+VERSION = "0.7.0"
 
 def version():
     """

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ tests_require = ['nose', 'mock', 'responses==0.5.1', 'unittest2']
 
 setup(
     name="keen",
-    version="0.6.1",
+    version="0.7.0",
     description="Python Client for Keen IO",
     long_description=codecs.open(os.path.join('README.rst'), 'r', encoding='UTF-8').read(),
     author="Keen IO",


### PR DESCRIPTION
Fixes https://github.com/keenlabs/KeenClient-Python/issues/161 which documents the motivation very clearly. 