### PR TITLE
docs: Fix a few typos

### DIFF
--- a/keen/api.py
+++ b/keen/api.py
@@ -300,7 +300,7 @@ class KeenApi(object):
         """
         Returns details on a particular access key. A master key must be set first.
 
-        :param key: the 'key' value of the access key to retreive data from
+        :param key: the 'key' value of the access key to retrieve data from
         """
         url = "{0}/{1}/projects/{2}/keys/{3}".format(self.base_url, self.api_version, self.project_id,
                                                      key)

--- a/keen/saved_queries.py
+++ b/keen/saved_queries.py
@@ -128,7 +128,7 @@ class SavedQueriesInterface:
         # for 'group_by', 'interval' or 'timezone', but those aren't accepted values when updating.
         old_query = old_saved_query[query_attr_name] # expected
 
-        # Shallow copy since we want the entire object heirarchy to start with.
+        # Shallow copy since we want the entire object hierarchy to start with.
         for (key, value) in six.iteritems(old_query):
             if value:
                 new_saved_query[query_attr_name][key] = value


### PR DESCRIPTION
There are small typos in:
- keen/api.py
- keen/saved_queries.py

Fixes:
- Should read `retrieve` rather than `retreive`.
- Should read `hierarchy` rather than `heirarchy`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md